### PR TITLE
docs: add GitHub status snapshot

### DIFF
--- a/docs/GITHUB_STATUS.md
+++ b/docs/GITHUB_STATUS.md
@@ -1,0 +1,18 @@
+# 📦 Estado actualizado del repositorio Git
+
+- **Fecha de actualización:** 2025-10-06T14:12:09+00:00 (UTC)
+- **Rama actual:** `work`
+- **Remotos configurados:** _ninguno definido_
+
+## 📜 Últimos commits
+- a9b5c700 | 2025-10-06 | jokken79 | 🧠 Descripción breve de los cambios
+- d0fcbaa3 | 2025-10-06 | jokken79 | Primer commit del proyecto JPUNS-CLAUDE2.0
+- 84237395 | 2025-10-06 | jokken79 | Add project files
+- a0700afc | 2025-10-06 | jokken79 | first commit
+
+## 📂 Estado del árbol de trabajo
+```
+## work
+```
+
+> ℹ️ Ejecuta `git remote add origin <URL>` y `git fetch --all` si necesitas enlazar este repositorio con GitHub.


### PR DESCRIPTION
## Summary
- add a GitHub status snapshot document with the latest commit metadata
- note the absence of configured remotes and provide guidance on linking to GitHub

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cd55fab08320b067be9b0cf2d233