### PR TITLE
Fix role validation for protected endpoints

### DIFF
--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.database import get_db
-from app.models.models import User
+from app.models.models import User, UserRole
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -100,15 +100,46 @@ class AuthService:
     @staticmethod
     def require_role(required_role: str):
         """Dependency to check user role"""
+
         async def role_checker(current_user: User = Depends(AuthService.get_current_active_user)):
-            allowed_roles = {
-                'super_admin': ['super_admin'],
-                'admin': ['super_admin', 'admin'],
-                'coordinator': ['super_admin', 'admin', 'coordinator'],
-                'employee': ['super_admin', 'admin', 'coordinator', 'employee']
+            role_hierarchy = {
+                UserRole.SUPER_ADMIN: {UserRole.SUPER_ADMIN},
+                UserRole.ADMIN: {UserRole.SUPER_ADMIN, UserRole.ADMIN},
+                UserRole.COORDINATOR: {UserRole.SUPER_ADMIN, UserRole.ADMIN, UserRole.COORDINATOR},
+                UserRole.EMPLOYEE: {
+                    UserRole.SUPER_ADMIN,
+                    UserRole.ADMIN,
+                    UserRole.COORDINATOR,
+                    UserRole.EMPLOYEE,
+                },
             }
 
-            if current_user.role.value not in allowed_roles.get(required_role, []):
+            try:
+                required_role_enum = UserRole(required_role.upper())
+            except ValueError as exc:  # pragma: no cover - configuration error
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail="Invalid role requirement configuration",
+                ) from exc
+
+            raw_current_role = current_user.role
+            if isinstance(raw_current_role, UserRole):
+                current_role = raw_current_role
+            else:
+                role_str = str(raw_current_role)
+                if role_str.startswith("UserRole."):
+                    role_str = role_str.split(".", 1)[1]
+                try:
+                    current_role = UserRole(role_str.upper())
+                except ValueError as exc:  # pragma: no cover - invalid data in DB
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail="Invalid role stored for current user",
+                    ) from exc
+
+            allowed_roles = role_hierarchy.get(required_role_enum, set())
+
+            if current_role not in allowed_roles:
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="Not enough permissions"


### PR DESCRIPTION
## Summary
- normalize role comparisons in the auth service so FastAPI dependencies respect the configured hierarchy
- restrict employee leave requests to their own profile by matching the authenticated user to an employee record

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68e50d1ad1088320823b7155253dd4fa