### PR TITLE
feat: refresh dashboard visuals

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -38,84 +38,113 @@ const Layout: React.FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-100 via-white to-indigo-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-32 -top-40 h-72 w-72 rounded-full bg-indigo-300/40 blur-3xl" />
+        <div className="absolute right-[-18%] top-1/3 h-[28rem] w-[28rem] rounded-full bg-violet-300/35 blur-[120px]" />
+        <div className="absolute bottom-[-20%] left-1/4 h-96 w-96 rounded-full bg-emerald-200/40 blur-[120px]" />
+      </div>
+
       {/* Top Navigation */}
-      <nav className="bg-white shadow-sm border-b border-gray-200 fixed w-full z-30">
-        <div className="px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between h-16">
-            <div className="flex items-center">
-              <button
-                onClick={() => setSidebarOpen(!sidebarOpen)}
-                className="p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500"
-              >
-                {sidebarOpen ? (
-                  <XMarkIcon className="h-6 w-6" />
-                ) : (
-                  <Bars3Icon className="h-6 w-6" />
-                )}
-              </button>
-              <div className="flex-shrink-0 flex items-center ml-4">
-                <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
-                  <span className="text-white text-lg font-bold">UNS</span>
-                </div>
-                <span className="ml-3 text-xl font-bold text-gray-900">UNS-ClaudeJP 2.0</span>
+      <nav className="fixed inset-x-0 top-0 z-40 px-4 pt-4 sm:px-6 lg:px-10">
+        <div className="mx-auto flex h-16 max-w-7xl items-center justify-between rounded-2xl border border-white/60 bg-white/80 px-4 shadow-lg shadow-slate-900/10 backdrop-blur">
+          <div className="flex items-center gap-4">
+            <button
+              onClick={() => setSidebarOpen(!sidebarOpen)}
+              aria-label={sidebarOpen ? 'サイドバーを閉じる' : 'サイドバーを開く'}
+              className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/70 bg-white/80 text-slate-500 transition hover:border-indigo-200 hover:text-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-white"
+            >
+              {sidebarOpen ? (
+                <XMarkIcon className="h-6 w-6" />
+              ) : (
+                <Bars3Icon className="h-6 w-6" />
+              )}
+            </button>
+            <div className="flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-indigo-500 via-sky-500 to-emerald-500 text-white shadow-lg shadow-indigo-500/20">
+                <span className="text-lg font-bold">UNS</span>
+              </div>
+              <div>
+                <p className="text-lg font-semibold text-slate-900">UNS-ClaudeJP 2.0</p>
+                <p className="text-xs text-slate-500">人材管理インテリジェンスプラットフォーム</p>
               </div>
             </div>
-            <div className="flex items-center">
-              <div className="text-sm text-gray-700 mr-4">
-                <span className="font-medium">管理者</span>
-              </div>
-              <button
-                onClick={handleLogout}
-                className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-              >
-                <ArrowRightOnRectangleIcon className="h-5 w-5 mr-2" />
-                ログアウト
-              </button>
+          </div>
+          <div className="flex items-center gap-4">
+            <div className="hidden text-right sm:flex sm:flex-col">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">ログイン中</span>
+              <span className="text-sm font-semibold text-slate-700">管理者</span>
             </div>
+            <button
+              onClick={handleLogout}
+              className="inline-flex items-center gap-2 rounded-xl bg-gradient-to-r from-rose-500 via-orange-500 to-amber-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-rose-500/20 transition hover:shadow-rose-500/40 focus:outline-none focus:ring-2 focus:ring-rose-400 focus:ring-offset-2 focus:ring-offset-white"
+            >
+              <ArrowRightOnRectangleIcon className="h-5 w-5" />
+              ログアウト
+            </button>
           </div>
         </div>
       </nav>
 
-      {/* Sidebar */}
-      <div className="flex pt-16">
+      {/* Sidebar & Main */}
+      <div className="relative z-10 flex pt-28">
         <div
-          className={`${
-            sidebarOpen ? 'w-64' : 'w-0'
-          } transition-all duration-300 ease-in-out overflow-hidden bg-white border-r border-gray-200 fixed h-full z-20`}
+          className={`${sidebarOpen ? 'w-72' : 'w-0'} transition-all duration-500 ease-in-out`}
         >
-          <nav className="mt-5 px-2 space-y-1">
-            {navigation.map((item) => {
-              const isActive = location.pathname === item.href || location.pathname.startsWith(item.href + '/');
-              return (
-                <Link
-                  key={item.name}
-                  to={item.href}
-                  className={`${
-                    isActive
-                      ? 'bg-blue-50 border-blue-500 text-blue-700'
-                      : 'border-transparent text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  } group flex items-center px-3 py-2 text-sm font-medium border-l-4 rounded-r-md transition-colors`}
-                >
-                  <item.icon
-                    className={`${
-                      isActive ? 'text-blue-500' : 'text-gray-400 group-hover:text-gray-500'
-                    } mr-3 flex-shrink-0 h-6 w-6`}
-                  />
-                  {item.name}
-                </Link>
-              );
-            })}
-          </nav>
+          <aside
+            className={`pointer-events-auto fixed top-24 bottom-8 left-4 right-auto z-30 flex h-[calc(100vh-7.5rem)] w-72 flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-4 shadow-2xl shadow-slate-900/10 backdrop-blur transition-transform duration-500 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+              sidebarOpen ? 'translate-x-0 opacity-100' : '-translate-x-[120%] opacity-0'
+            } sm:left-6 lg:left-10`}
+          >
+            <div className="flex items-center justify-between pb-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">Navigation</p>
+              <span className="rounded-full bg-slate-900/5 px-3 py-1 text-[0.65rem] font-semibold text-slate-500">HR Suite</span>
+            </div>
+            <nav className="flex flex-1 flex-col gap-2 overflow-y-auto pr-1">
+              {navigation.map((item) => {
+                const isActive =
+                  location.pathname === item.href || location.pathname.startsWith(item.href + '/');
+                return (
+                  <Link
+                    key={item.name}
+                    to={item.href}
+                    className={`group relative flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold transition-all duration-300 ${
+                      isActive
+                        ? 'bg-gradient-to-r from-indigo-500/15 via-sky-500/10 to-indigo-500/15 text-indigo-600 shadow-lg shadow-indigo-500/20 ring-1 ring-indigo-200/60'
+                        : 'text-slate-600 hover:bg-white/70 hover:text-slate-900 hover:shadow-sm'
+                    }`}
+                  >
+                    <span
+                      className={`flex h-10 w-10 items-center justify-center rounded-xl border ${
+                        isActive
+                          ? 'border-indigo-300 bg-white text-indigo-500'
+                          : 'border-white/70 bg-white/80 text-slate-500 group-hover:border-indigo-200 group-hover:text-indigo-500'
+                      }`}
+                    >
+                      <item.icon className="h-5 w-5" />
+                    </span>
+                    <span className="truncate">{item.name}</span>
+                    {isActive && (
+                      <span className="absolute inset-y-1 left-1 w-1 rounded-full bg-indigo-500" aria-hidden="true" />
+                    )}
+                  </Link>
+                );
+              })}
+            </nav>
+            <div className="mt-6 rounded-2xl border border-dashed border-slate-200/80 bg-slate-50/80 p-4 text-xs font-medium text-slate-500">
+              卓越した人材エクスペリエンスを実現するためのインサイトを提供します。
+            </div>
+          </aside>
         </div>
 
-        {/* Main content */}
         <main
-          className={`${
-            sidebarOpen ? 'ml-64' : 'ml-0'
-          } transition-all duration-300 ease-in-out flex-1 px-4 sm:px-6 lg:px-8 py-8`}
+          className={`flex-1 px-4 pb-12 transition-all duration-500 sm:px-6 lg:px-10 ${
+            sidebarOpen ? 'md:ml-[19rem]' : 'md:ml-20'
+          }`}
         >
-          <Outlet />
+          <div className="mx-auto w-full max-w-7xl space-y-10">
+            <Outlet />
+          </div>
         </main>
       </div>
     </div>

--- a/frontend/src/components/dashboard/Alerts.tsx
+++ b/frontend/src/components/dashboard/Alerts.tsx
@@ -7,43 +7,72 @@ interface AlertsProps {
 }
 
 const Alerts: React.FC<AlertsProps> = ({ alerts }) => {
+  const severityStyles = {
+    warning: {
+      accent: 'from-amber-400/20 via-amber-300/10 to-yellow-300/20',
+      badge: 'bg-amber-500/15 text-amber-700',
+      label: '優先度: 高',
+      border: 'bg-amber-400/80',
+    },
+    info: {
+      accent: 'from-sky-400/20 via-blue-300/10 to-indigo-300/20',
+      badge: 'bg-indigo-500/15 text-indigo-700',
+      label: '優先度: 中',
+      border: 'bg-indigo-400/80',
+    },
+  } as const;
+
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-gray-900 flex items-center">
-          <ExclamationTriangleIcon className="h-6 w-6 mr-2 text-yellow-500" />
-          アラート
-        </h2>
-        <button className="text-sm text-primary-600 hover:text-primary-700 font-medium">
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-slate-900/5 backdrop-blur">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-amber-400/15 text-amber-600">
+            <ExclamationTriangleIcon className="h-6 w-6" />
+          </span>
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">アラート</h2>
+            <p className="text-sm text-slate-600">重要な期限とフォローアップを見逃さないように管理</p>
+          </div>
+        </div>
+        <button className="rounded-full border border-transparent bg-slate-900/5 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-900/10 hover:bg-slate-900/10">
           すべて表示
         </button>
       </div>
-      <div className="space-y-3">
-        {alerts.map((alert) => (
-          <div
-            key={alert.id}
-            className={`p-4 rounded-lg border-l-4 ${
-              alert.severity === 'warning'
-                ? 'bg-yellow-50 border-yellow-400'
-                : 'bg-blue-50 border-blue-400'
-            }`}
-          >
-            <p className="font-medium text-gray-900">{alert.employee}</p>
-            <p className="text-sm text-gray-600 mt-1">{alert.type}</p>
-            {'daysUntil' in alert && (
-              <p className="text-sm text-gray-500 mt-1">
-                あと{alert.daysUntil}日
-              </p>
-            )}
-            {'remaining' in alert && (
-              <p className="text-sm text-gray-500 mt-1">
-                残り{alert.remaining}日
-              </p>
-            )}
-          </div>
-        ))}
+      <div className="mt-6 space-y-4">
+        {alerts.map((alert) => {
+          const severity = severityStyles[alert.severity];
+
+          return (
+            <article
+              key={alert.id}
+              className="relative overflow-hidden rounded-2xl border border-white/70 bg-white/80 p-4 shadow-sm shadow-slate-900/5 transition hover:shadow-lg"
+            >
+              <div className={`absolute inset-0 opacity-80 bg-gradient-to-r ${severity.accent}`} />
+              <div className="relative flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-base font-semibold text-slate-900">{alert.employee}</p>
+                  <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${severity.badge}`}>
+                    <span className={`h-2 w-2 rounded-full ${severity.border}`} />
+                    {severity.label}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-700">{alert.type}</p>
+                {'daysUntil' in alert && (
+                  <p className="text-xs font-medium text-slate-600">
+                    期限まであと <span className="font-semibold text-slate-900">{alert.daysUntil}日</span>
+                  </p>
+                )}
+                {'remaining' in alert && (
+                  <p className="text-xs font-medium text-slate-600">
+                    残り日数 <span className="font-semibold text-slate-900">{alert.remaining}日</span>
+                  </p>
+                )}
+              </div>
+            </article>
+          );
+        })}
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/dashboard/RecentActivities.tsx
+++ b/frontend/src/components/dashboard/RecentActivities.tsx
@@ -8,35 +8,44 @@ interface RecentActivitiesProps {
 
 const RecentActivities: React.FC<RecentActivitiesProps> = ({ recentActivities }) => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-gray-900 flex items-center">
-          <ChartBarIcon className="h-6 w-6 mr-2 text-primary-500" />
-          最新のアクティビティ
-        </h2>
-        <button className="text-sm text-primary-600 hover:text-primary-700 font-medium">
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-slate-900/5 backdrop-blur">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-indigo-500/15 text-indigo-600">
+            <ChartBarIcon className="h-6 w-6" />
+          </span>
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">最新のアクティビティ</h2>
+            <p className="text-sm text-slate-600">チームの更新状況と重要なトランザクションを追跡</p>
+          </div>
+        </div>
+        <button className="rounded-full border border-transparent bg-slate-900/5 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-900/10 hover:bg-slate-900/10">
           すべて表示
         </button>
       </div>
-      <div className="space-y-4">
-        {recentActivities.map((activity) => (
-          <div key={activity.id} className="flex items-start space-x-3">
-            <div className="flex-shrink-0 w-2 h-2 mt-2 bg-primary-500 rounded-full"></div>
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900">
-                {activity.type}
-              </p>
-              <p className="text-sm text-gray-600 mt-1">
-                {activity.description}
-              </p>
-              <p className="text-xs text-gray-500 mt-1">
-                {activity.time} • {activity.user}
-              </p>
-            </div>
-          </div>
-        ))}
+      <div className="relative mt-6">
+        <div className="absolute left-[1.4rem] top-0 bottom-0 w-px bg-gradient-to-b from-indigo-200 via-slate-200 to-transparent" aria-hidden="true" />
+        <div className="space-y-6">
+          {recentActivities.map((activity, index) => (
+            <article key={activity.id} className="relative flex gap-4 pl-14">
+              <div className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-2xl border border-white/70 bg-white text-indigo-600 shadow-sm shadow-slate-900/10">
+                <span className="text-sm font-semibold">{String(index + 1).padStart(2, '0')}</span>
+              </div>
+              <div className="flex-1 space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <p className="text-base font-semibold text-slate-900">{activity.type}</p>
+                  <span className="rounded-full bg-indigo-500/10 px-3 py-1 text-xs font-semibold text-indigo-600">
+                    {activity.time}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-700">{activity.description}</p>
+                <p className="text-xs font-medium text-slate-500">更新者: {activity.user}</p>
+              </div>
+            </article>
+          ))}
+        </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/dashboard/StatsGrid.tsx
+++ b/frontend/src/components/dashboard/StatsGrid.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
 import { Stat } from '../../hooks/useDashboardData';
+import {
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
+  MinusSmallIcon,
+} from '@heroicons/react/24/outline';
 
 interface StatsGridProps {
   stats: Stat[];
@@ -7,34 +12,66 @@ interface StatsGridProps {
 
 const StatsGrid: React.FC<StatsGridProps> = ({ stats }) => {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      {stats.map((stat) => (
-        <div
-          key={stat.name}
-          className="bg-white rounded-xl shadow-sm p-6 hover:shadow-md transition"
-        >
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
-              <p className="text-sm font-medium text-gray-600">{stat.name}</p>
-              <p className="mt-2 text-3xl font-bold text-gray-900">{stat.value}</p>
-              <p
-                className={`mt-2 text-sm font-medium ${
-                  stat.changeType === 'increase'
-                    ? 'text-green-600'
-                    : stat.changeType === 'decrease'
-                    ? 'text-red-600'
-                    : 'text-gray-600'
-                }`}
-              >
-                {stat.change} 先月比
-              </p>
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+      {stats.map((stat) => {
+        const trendStyles =
+          stat.changeType === 'increase'
+            ? {
+                icon: ArrowTrendingUpIcon,
+                badge: 'bg-emerald-500/10 text-emerald-600',
+                label: 'ポジティブな推移',
+              }
+            : stat.changeType === 'decrease'
+            ? {
+                icon: ArrowTrendingDownIcon,
+                badge: 'bg-rose-500/10 text-rose-600',
+                label: '注意が必要',
+              }
+            : {
+                icon: MinusSmallIcon,
+                badge: 'bg-slate-500/10 text-slate-600',
+                label: '安定推移',
+              };
+
+        const TrendIcon = trendStyles.icon;
+
+        return (
+          <article
+            key={stat.name}
+            className="group relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-slate-900/5 backdrop-blur transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl"
+          >
+            <div
+              className={`pointer-events-none absolute inset-0 opacity-80 transition-opacity duration-500 group-hover:opacity-100 bg-gradient-to-br ${stat.gradient}`}
+            />
+            <div className="relative flex h-full flex-col justify-between gap-6">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <span className="inline-flex items-center rounded-full bg-white/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm">
+                    {stat.name}
+                  </span>
+                  <p className="mt-4 text-4xl font-semibold leading-tight text-slate-900">
+                    {stat.value}
+                  </p>
+                </div>
+                <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/70 bg-white/80 shadow-inner shadow-white/40">
+                  <stat.icon className="h-7 w-7 text-slate-700" />
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-sm font-semibold text-slate-700">
+                <div className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${trendStyles.badge}`}>
+                  <TrendIcon className="h-4 w-4" />
+                  <span>{trendStyles.label}</span>
+                </div>
+                <p className="text-base font-semibold text-slate-800">
+                  {stat.change}
+                  <span className="ml-1 text-sm font-medium text-slate-600">先月比</span>
+                </p>
+              </div>
             </div>
-            <div className={`${stat.color} rounded-xl p-3`}>
-              <stat.icon className="h-8 w-8 text-white" />
-            </div>
-          </div>
-        </div>
-      ))}
+            <div className="pointer-events-none absolute -bottom-16 -right-16 h-40 w-40 rounded-full bg-white/60 blur-3xl transition-transform duration-500 group-hover:translate-x-6 group-hover:-translate-y-4" />
+          </article>
+        );
+      })}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/TopFactories.tsx
+++ b/frontend/src/components/dashboard/TopFactories.tsx
@@ -8,63 +8,65 @@ interface TopFactoriesProps {
 
 const TopFactories: React.FC<TopFactoriesProps> = ({ topFactories }) => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-xl font-bold text-gray-900 flex items-center">
-          <ArrowTrendingUpIcon className="h-6 w-6 mr-2 text-green-500" />
-          利益率上位の企業
-        </h2>
-        <button className="text-sm text-primary-600 hover:text-primary-700 font-medium">
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-6 shadow-xl shadow-slate-900/5 backdrop-blur">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-emerald-500/15 text-emerald-600">
+            <ArrowTrendingUpIcon className="h-6 w-6" />
+          </span>
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">利益率上位の企業</h2>
+            <p className="text-sm text-slate-600">パフォーマンスの高い企業をリアルタイムに把握</p>
+          </div>
+        </div>
+        <button className="rounded-full border border-transparent bg-slate-900/5 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:border-slate-900/10 hover:bg-slate-900/10">
           すべての企業を表示
         </button>
       </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead>
+      <div className="mt-6 overflow-x-auto">
+        <table className="min-w-full overflow-hidden rounded-2xl border border-white/70 text-left shadow-sm">
+          <thead className="bg-gradient-to-r from-slate-100 via-white to-slate-100/60 text-xs font-semibold uppercase tracking-[0.08em] text-slate-500">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                企業ID
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                企業名
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                後継技能者数
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                先月比利益
-              </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                利益率
-              </th>
+              <th className="px-6 py-4">企業ID</th>
+              <th className="px-6 py-4">企業名</th>
+              <th className="px-6 py-4">後継技能者数</th>
+              <th className="px-6 py-4">先月比利益</th>
+              <th className="px-6 py-4">利益率</th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="divide-y divide-slate-100/70 bg-white/80 text-sm text-slate-700">
             {topFactories.map((factory) => (
-              <tr key={factory.id} className="hover:bg-gray-50 cursor-pointer transition">
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                  {factory.id}
+              <tr key={factory.id} className="transition hover:bg-indigo-50/60">
+                <td className="px-6 py-4 font-semibold text-slate-900">{factory.id}</td>
+                <td className="px-6 py-4">
+                  <div className="flex flex-col">
+                    <span className="font-medium text-slate-900">{factory.name}</span>
+                    <span className="text-xs text-slate-500">トップパフォーマンス企業</span>
+                  </div>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                  {factory.name}
+                <td className="px-6 py-4 text-slate-600">{factory.employees}名</td>
+                <td className="px-6 py-4 text-emerald-600">
+                  <span className="font-semibold">{factory.profit}</span>
                 </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-600">
-                  {factory.employees}名
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-semibold text-green-600">
-                  {factory.profit}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap">
-                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                    {factory.margin}%
-                  </span>
+                <td className="px-6 py-4">
+                  <div className="flex items-center gap-3">
+                    <span className="inline-flex min-w-[3rem] items-center justify-center rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-600">
+                      {factory.margin}%
+                    </span>
+                    <div className="h-2 flex-1 rounded-full bg-slate-200">
+                      <div
+                        className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-emerald-500 to-teal-500"
+                        style={{ width: `${Math.min(factory.margin, 100)}%` }}
+                      />
+                    </div>
+                  </div>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/skeletons/ActivitySkeleton.tsx
+++ b/frontend/src/components/skeletons/ActivitySkeleton.tsx
@@ -1,30 +1,38 @@
 import React from 'react';
 
 const ActivityItemSkeleton: React.FC = () => (
-  <div className="flex items-start space-x-3">
-    <div className="flex-shrink-0 w-2 h-2 mt-2 bg-gray-200 rounded-full"></div>
-    <div className="flex-1 min-w-0">
-      <div className="h-4 bg-gray-300 rounded w-1/4 mb-2"></div>
-      <div className="h-3 bg-gray-200 rounded w-3/4 mb-2"></div>
-      <div className="h-3 bg-gray-200 rounded w-1/2"></div>
+  <div className="relative flex gap-4 pl-14">
+    <div className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-2xl border border-white/70 bg-white/80 shadow-sm">
+      <div className="h-4 w-4 rounded-full bg-slate-200/80 animate-pulse" />
+    </div>
+    <div className="flex-1 space-y-2">
+      <div className="h-4 w-1/3 rounded-full bg-slate-200/80 animate-pulse" />
+      <div className="h-3 w-3/4 rounded-full bg-slate-200/80 animate-pulse" />
+      <div className="h-3 w-1/2 rounded-full bg-slate-200/70 animate-pulse" />
     </div>
   </div>
 );
 
 const ActivitySkeleton: React.FC = () => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6 animate-pulse">
-      <div className="flex items-center justify-between mb-4">
-        <div className="h-6 bg-gray-300 rounded w-1/3"></div>
-        <div className="h-4 bg-gray-200 rounded w-1/4"></div>
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-6 shadow-xl shadow-slate-900/5">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-100/60 via-white to-slate-200/50" aria-hidden="true" />
+      <div className="relative space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-6 w-40 rounded-full bg-slate-200/80 animate-pulse" />
+          <div className="h-4 w-24 rounded-full bg-slate-200/80 animate-pulse" />
+        </div>
+        <div className="relative">
+          <div className="absolute left-[1.4rem] top-0 bottom-0 w-px bg-slate-200/60" aria-hidden="true" />
+          <div className="space-y-6">
+            <ActivityItemSkeleton />
+            <ActivityItemSkeleton />
+            <ActivityItemSkeleton />
+            <ActivityItemSkeleton />
+          </div>
+        </div>
       </div>
-      <div className="space-y-4">
-        <ActivityItemSkeleton />
-        <ActivityItemSkeleton />
-        <ActivityItemSkeleton />
-        <ActivityItemSkeleton />
-      </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/skeletons/AlertSkeleton.tsx
+++ b/frontend/src/components/skeletons/AlertSkeleton.tsx
@@ -1,25 +1,31 @@
 import React from 'react';
 
 const AlertItemSkeleton: React.FC = () => (
-  <div className="p-4 rounded-lg border-l-4 bg-gray-50 border-gray-200">
-    <div className="h-4 bg-gray-200 rounded w-1/2 mb-2"></div>
-    <div className="h-3 bg-gray-200 rounded w-3/4"></div>
+  <div className="relative overflow-hidden rounded-2xl border border-white/70 bg-white/80 p-4 shadow-sm">
+    <div className="absolute inset-0 bg-gradient-to-r from-slate-100 via-white to-slate-100/60" aria-hidden="true" />
+    <div className="relative space-y-2">
+      <div className="h-4 w-1/2 rounded-full bg-slate-200/80 animate-pulse" />
+      <div className="h-3 w-3/4 rounded-full bg-slate-200/80 animate-pulse" />
+    </div>
   </div>
 );
 
 const AlertSkeleton: React.FC = () => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6 animate-pulse">
-      <div className="flex items-center justify-between mb-4">
-        <div className="h-6 bg-gray-300 rounded w-1/3"></div>
-        <div className="h-4 bg-gray-200 rounded w-1/4"></div>
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-6 shadow-xl shadow-slate-900/5">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-100/70 via-white to-slate-200/50" aria-hidden="true" />
+      <div className="relative space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-6 w-32 rounded-full bg-slate-200/80 animate-pulse" />
+          <div className="h-4 w-24 rounded-full bg-slate-200/80 animate-pulse" />
+        </div>
+        <div className="space-y-3">
+          <AlertItemSkeleton />
+          <AlertItemSkeleton />
+          <AlertItemSkeleton />
+        </div>
       </div>
-      <div className="space-y-3">
-        <AlertItemSkeleton />
-        <AlertItemSkeleton />
-        <AlertItemSkeleton />
-      </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/skeletons/FactoriesTableSkeleton.tsx
+++ b/frontend/src/components/skeletons/FactoriesTableSkeleton.tsx
@@ -2,36 +2,39 @@ import React from 'react';
 
 const FactoriesTableSkeleton: React.FC = () => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6 animate-pulse">
-      <div className="flex items-center justify-between mb-4">
-        <div className="h-6 bg-gray-300 rounded w-1/3"></div>
-        <div className="h-4 bg-gray-200 rounded w-1/4"></div>
-      </div>
-      <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead>
-            <tr>
-              <th className="px-6 py-3"><div className="h-4 bg-gray-200 rounded w-full"></div></th>
-              <th className="px-6 py-3"><div className="h-4 bg-gray-200 rounded w-full"></div></th>
-              <th className="px-6 py-3"><div className="h-4 bg-gray-200 rounded w-full"></div></th>
-              <th className="px-6 py-3"><div className="h-4 bg-gray-200 rounded w-full"></div></th>
-              <th className="px-6 py-3"><div className="h-4 bg-gray-200 rounded w-full"></div></th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {[...Array(3)].map((_, i) => (
-              <tr key={i}>
-                <td className="px-6 py-4"><div className="h-4 bg-gray-200 rounded w-full"></div></td>
-                <td className="px-6 py-4"><div className="h-4 bg-gray-200 rounded w-full"></div></td>
-                <td className="px-6 py-4"><div className="h-4 bg-gray-200 rounded w-full"></div></td>
-                <td className="px-6 py-4"><div className="h-4 bg-gray-200 rounded w-full"></div></td>
-                <td className="px-6 py-4"><div className="h-4 bg-gray-200 rounded w-full"></div></td>
+    <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-6 shadow-xl shadow-slate-900/5">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-100/60 via-white to-slate-200/50" aria-hidden="true" />
+      <div className="relative space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="h-6 w-40 rounded-full bg-slate-200/80 animate-pulse" />
+          <div className="h-4 w-24 rounded-full bg-slate-200/80 animate-pulse" />
+        </div>
+        <div className="overflow-hidden rounded-2xl border border-white/70">
+          <table className="min-w-full text-left">
+            <thead className="bg-slate-100/60">
+              <tr>
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <th key={index} className="px-6 py-4">
+                    <div className="h-4 w-full rounded-full bg-slate-200/80 animate-pulse" />
+                  </th>
+                ))}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody className="divide-y divide-slate-100/70 bg-white/70">
+              {Array.from({ length: 3 }).map((_, row) => (
+                <tr key={row}>
+                  {Array.from({ length: 5 }).map((_, col) => (
+                    <td key={col} className="px-6 py-4">
+                      <div className="h-4 w-full rounded-full bg-slate-200/80 animate-pulse" />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/src/components/skeletons/StatCardSkeleton.tsx
+++ b/frontend/src/components/skeletons/StatCardSkeleton.tsx
@@ -2,32 +2,28 @@ import React from 'react';
 
 const StatCardSkeleton: React.FC = () => {
   return (
-    <div className="bg-white rounded-xl shadow-sm p-6">
-      <div className="animate-pulse flex items-center justify-between">
-        <div className="flex-1">
-          <div className="h-4 bg-gray-200 rounded w-3/4 mb-3"></div>
-          <div className="h-8 bg-gray-300 rounded w-1/2 mb-3"></div>
-          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+    <div className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-6 shadow-xl shadow-slate-900/5">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-200/40 via-white to-slate-100/40" aria-hidden="true" />
+      <div className="relative flex items-center justify-between gap-4">
+        <div className="flex-1 space-y-3">
+          <div className="h-3 w-24 rounded-full bg-slate-200/80 animate-pulse" />
+          <div className="h-10 w-40 rounded-2xl bg-slate-200/80 animate-pulse" />
+          <div className="h-3 w-28 rounded-full bg-slate-200/80 animate-pulse" />
         </div>
-        <div className="w-14 h-14 bg-gray-200 rounded-xl"></div>
+        <div className="h-14 w-14 rounded-2xl bg-slate-200/80 animate-pulse" />
       </div>
     </div>
   );
 };
 
 export const StatsGridSkeleton: React.FC = () => {
-    return (
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-        <StatCardSkeleton />
-      </div>
-    );
-  };
+  return (
+    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
+      {Array.from({ length: 8 }).map((_, index) => (
+        <StatCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+};
 
 export default StatCardSkeleton;

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -6,9 +6,7 @@ import {
   ClockIcon,
   CurrencyYenIcon,
   DocumentCheckIcon,
-  ExclamationTriangleIcon,
   ArrowTrendingUpIcon,
-  ChartBarIcon
 } from '@heroicons/react/24/outline';
 
 // Interfaces para tipar los datos
@@ -18,7 +16,7 @@ export interface Stat {
   change: string;
   changeType: 'increase' | 'decrease' | 'neutral';
   icon: React.ElementType;
-  color: string;
+  gradient: string;
 }
 
 export interface Alert {
@@ -61,69 +59,69 @@ const useDashboardData = () => {
       // Datos de ejemplo
       setStats([
         {
-            name: '登録従業員数',
-            value: '150',
-            change: '+12',
-            changeType: 'increase',
-            icon: UserGroupIcon,
-            color: 'bg-blue-500'
-          },
-          {
-            name: '承認待ち',
-            value: '12',
-            change: '+3',
-            changeType: 'increase',
-            icon: DocumentCheckIcon,
-            color: 'bg-yellow-500'
-          },
-          {
-            name: '後継技能者数',
-            value: '320',
-            change: '+8',
-            changeType: 'increase',
-            icon: UserGroupIcon,
-            color: 'bg-green-500'
-          },
-          {
-            name: '派遣中後継技能者',
-            value: '305',
-            change: '-2',
-            changeType: 'decrease',
-            icon: UserGroupIcon,
-            color: 'bg-emerald-500'
-          },
-          {
-            name: '企業数',
-            value: '20',
-            change: '0',
-            changeType: 'neutral',
-            icon: BuildingOfficeIcon,
-            color: 'bg-purple-500'
-          },
-          {
-            name: '承認待ち申請',
-            value: '8',
-            change: '+2',
-            changeType: 'increase',
-            icon: ClockIcon,
-            color: 'bg-orange-500'
-          },
-          {
-            name: '今月給与支給額',
-            value: '¥45,000,000',
-            change: '+5.2%',
-            changeType: 'increase',
-            icon: CurrencyYenIcon,
-            color: 'bg-green-600'
-          },
-          {
-            name: '今月利益',
-            value: '¥8,500,000',
-            change: '+3.8%',
-            changeType: 'increase',
-            icon: ArrowTrendingUpIcon,
-            color: 'bg-indigo-500'
-          }
+          name: '登録従業員数',
+          value: '150',
+          change: '+12',
+          changeType: 'increase',
+          icon: UserGroupIcon,
+          gradient: 'from-sky-400/90 via-blue-500/90 to-indigo-500/90'
+        },
+        {
+          name: '承認待ち',
+          value: '12',
+          change: '+3',
+          changeType: 'increase',
+          icon: DocumentCheckIcon,
+          gradient: 'from-amber-400/90 via-orange-400/80 to-yellow-400/90'
+        },
+        {
+          name: '後継技能者数',
+          value: '320',
+          change: '+8',
+          changeType: 'increase',
+          icon: UserGroupIcon,
+          gradient: 'from-emerald-400/90 via-emerald-500/90 to-teal-500/90'
+        },
+        {
+          name: '派遣中後継技能者',
+          value: '305',
+          change: '-2',
+          changeType: 'decrease',
+          icon: UserGroupIcon,
+          gradient: 'from-emerald-500/90 via-green-500/80 to-emerald-600/90'
+        },
+        {
+          name: '企業数',
+          value: '20',
+          change: '0',
+          changeType: 'neutral',
+          icon: BuildingOfficeIcon,
+          gradient: 'from-violet-400/90 via-purple-400/80 to-indigo-500/90'
+        },
+        {
+          name: '承認待ち申請',
+          value: '8',
+          change: '+2',
+          changeType: 'increase',
+          icon: ClockIcon,
+          gradient: 'from-orange-400/90 via-amber-400/80 to-rose-400/90'
+        },
+        {
+          name: '今月給与支給額',
+          value: '¥45,000,000',
+          change: '+5.2%',
+          changeType: 'increase',
+          icon: CurrencyYenIcon,
+          gradient: 'from-emerald-400/90 via-emerald-500/80 to-green-600/90'
+        },
+        {
+          name: '今月利益',
+          value: '¥8,500,000',
+          change: '+3.8%',
+          changeType: 'increase',
+          icon: ArrowTrendingUpIcon,
+          gradient: 'from-indigo-400/90 via-blue-500/80 to-purple-500/90'
+        }
       ]);
       setAlerts([
         {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -17,12 +17,33 @@ const Dashboard: React.FC = () => {
   const { stats, alerts, recentActivities, topFactories, loading } = useDashboardData();
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       {/* Header */}
-      <div>
-        <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
-        <p className="mt-2 text-gray-600">システムの概要と最新のアクティビティ</p>
-      </div>
+      <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-white/80 p-8 shadow-xl shadow-slate-900/5 backdrop-blur">
+        <div className="absolute inset-y-0 right-0 hidden w-1/2 translate-x-1/4 rounded-l-full bg-gradient-to-br from-indigo-400/20 via-sky-300/20 to-emerald-300/20 blur-3xl md:block" aria-hidden="true" />
+        <div className="relative flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-indigo-500">Insight Center</p>
+            <h1 className="mt-3 text-4xl font-semibold text-slate-900 lg:text-5xl">ダッシュボード</h1>
+            <p className="mt-4 max-w-2xl text-base text-slate-600">
+              組織全体のパフォーマンス、重要アラート、最新動向をワンビューで把握。意思決定を加速させるエグゼクティブレベルの分析体験を提供します。
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            <div className="flex items-center gap-3 rounded-2xl border border-white/70 bg-white/80 px-4 py-3 shadow-sm shadow-slate-900/5">
+              <span className="h-2 w-2 rounded-full bg-emerald-500 animate-pulse" />
+              <div>
+                <p className="text-xs font-semibold text-slate-500">システムステータス</p>
+                <p className="text-sm font-semibold text-slate-900">稼働中 / リアルタイム更新</p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3 rounded-2xl border border-white/70 bg-white/80 px-4 py-3 shadow-sm shadow-slate-900/5">
+              <span className="rounded-full bg-indigo-500/15 px-3 py-1 text-xs font-semibold text-indigo-600">HR Excellence</span>
+              <div className="text-sm font-semibold text-slate-700">KPI最適化ビュー</div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {/* Stats Grid */}
       <Suspense fallback={<StatsGridSkeleton />}>
@@ -30,7 +51,7 @@ const Dashboard: React.FC = () => {
       </Suspense>
 
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
         {/* Alerts */}
         <Suspense fallback={<AlertSkeleton />}>
             {loading ? <AlertSkeleton /> : <Alerts alerts={alerts} />}


### PR DESCRIPTION
## Summary
- redesign the global layout with gradient chrome, glassmorphism navigation, and a responsive sidebar
- elevate the dashboard hero, stats, alerts, activities, and top factories cards with premium gradients and timeline styling
- align skeleton loaders and data hooks with the new visual language for a cohesive loading experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6850d55b8832097606c6b518fc9e3